### PR TITLE
384: Patch revoke consent (#85)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -156,7 +156,7 @@ declare namespace SDKStandardComponents {
         transactionRequestId: string;
         authenticationType: 'U2F';
         retriesLeft: string;
-        amount: TAmount;
+        amount: TMoney;
         transactionId: string;
         quote: TQuotesIDPutResponse;
     }
@@ -185,6 +185,11 @@ declare namespace SDKStandardComponents {
         value: string;
     }
 
+    type PatchConsentsRequest = {
+        status: 'REVOKED';
+        revokedAt: string;
+    }
+
     class BaseRequests {
         constructor(config: BaseRequestConfigType)
     }
@@ -208,6 +213,15 @@ declare namespace SDKStandardComponents {
      *   for 3rd party functions (e.g. PISP use cases)
      */
     class ThirdpartyRequests extends BaseRequests {
+        /**
+         * @function patchConsents
+         * @description Executes a `PATCH /consents/{id}` request.
+         * @param {string} consentId The `id` of the consent object to be updated
+         * @param {PatchConsentsRequest} consentBody The body of the consent object
+         * @param {string} destParticipantId The id of the destination participant
+         */
+        patchConsents(consentId: string, consentBody: PatchConsentsRequest, destParticipantId: string): Promise<GenericRequestResponse | MojaloopRequestResponse>;
+
         /**
          * @function putConsents
          * @description Executes a `PUT /consents/{id}` request.

--- a/src/lib/requests/thirdpartyRequests.js
+++ b/src/lib/requests/thirdpartyRequests.js
@@ -3,6 +3,11 @@
 const BaseRequests = require('./baseRequests');
 
 class ThirdpartyRequests extends BaseRequests {
+    async patchConsents(consentId, consentBody, destParticipantId) {
+        const url = `consents/${consentId}`;
+        return this._patch(url, 'thirdparty', consentBody, destParticipantId);
+    }
+
     async putConsents(consentId, consentBody, destParticipantId) {
         const url = `consents/${consentId}`;
         return this._put(url, 'thirdparty', consentBody, destParticipantId);

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/sdk-standard-components",
-  "version": "10.6.8",
+  "version": "10.6.9",
   "description": "A set of standard components for connecting to Mojaloop API enabled Switches",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/test/unit/data/patchConsentsRequest.json
+++ b/src/test/unit/data/patchConsentsRequest.json
@@ -1,0 +1,6 @@
+{
+    "status": "REVOKED",
+    "revokedAt": "2011-10-05T14:48:00.000Z"
+}
+  
+  

--- a/src/test/unit/lib/requests/thirdpartyRequests.test.js
+++ b/src/test/unit/lib/requests/thirdpartyRequests.test.js
@@ -86,6 +86,83 @@ describe('ThirdpartyRequests', () => {
         });
     });
 
+    describe('patchConsents', () => {
+        const patchConsentsRequest = require('../../data/patchConsentsRequest.json');
+        const wso2Auth = new WSO2Auth({ logger: mockLogger({ app: 'patch-consents-test' }) });
+        const config = {
+            logger: mockLogger({ app: 'patch-consents-test' }),
+            peerEndpoint: '127.0.0.1',
+            thirdpartyRequestsEndpoint: 'thirdparty-api-adapter.local',
+            tls: {
+                outbound: {
+                    mutualTLS: {
+                        enabled: false
+                    }
+                }
+            },
+            jwsSign: false,
+            jwsSignPutParties: false,
+            jwsSigningKey: jwsSigningKey,
+            wso2Auth,
+        };
+        const config2 = {
+            logger: mockLogger({ app: 'patch-consents-test' }),
+            peerEndpoint: '127.0.0.1',
+            thirdpartyRequestsEndpoint: 'thirdparty-api-adapter.local',
+            tls: {
+                outbound: {
+                    mutualTLS: {
+                        enabled: false
+                    }
+                }
+            },
+            jwsSign: true,
+            jwsSignPutParties: false,
+            jwsSigningKey: jwsSigningKey,
+            wso2Auth,
+        };
+        http.__request = jest.fn(() => ({
+            statusCode: 202,
+            headers: {
+                'content-length': 0
+            },
+        }));
+        const consentId = '123';
+        const expected = expect.objectContaining({
+            host: 'thirdparty-api-adapter.local',
+            method: 'PATCH',
+            path: '/consents/123',
+            headers: expect.objectContaining({
+                'fspiop-destination': 'dfspa'
+            })
+        });
+
+        it('executes a `PATCH /consents/{id}` request', async () => {
+            // Init
+            const tpr = new ThirdpartyRequests(config);
+            
+
+            // Act
+            await tpr.patchConsents(consentId, patchConsentsRequest, 'dfspa');
+
+            // Assert
+            expect(http.__write).toHaveBeenCalledWith((JSON.stringify(patchConsentsRequest)));
+            expect(http.__request).toHaveBeenCalledWith(expected);
+        });
+
+        it('executes a `PATCH /consents/{id}` request with signing enabled', async () => {
+            // Init
+            const tpr = new ThirdpartyRequests(config2);
+            
+            // Act
+            await tpr.patchConsents(consentId, patchConsentsRequest, 'dfspa');
+
+            // Assert
+            expect(http.__write).toHaveBeenCalledWith((JSON.stringify(patchConsentsRequest)));
+            expect(http.__request).toHaveBeenCalledWith(expected);
+        });
+    });
+
     describe('postConsents', () => {
         const postConsentsRequest = require('../../data/postConsentsRequest.json');
         const wso2Auth = new WSO2Auth({ logger: mockLogger({ app: 'post-consents-test' }) });


### PR DESCRIPTION
* feat: BaseRequests _patch method

* feat: ThirdPartyRequest patchConsents method

* docs: New interface for PatchConsentsRequest +
Definition for patchConsents method

* add id field to PatchConsentsRequest

* Update Payload Type

Allow it to be string or undefined in alignment with Auth Service internal consent model

* Update PatchConsentsRequest type

* Rollback change to TCredential payload type

* fix: Undefined type was previously assigned to amount

* chore: Added Node type definitions
To deal with linting error

* fix: change type of revokedAt to string

* Revert "chore: Added Node type definitions"

This reverts commit 157acb7029a57f3663b50d4036ba23819cca64ac.

* fix: indentation lint error

* test: Unit tests for patchConsents()

* test: add unit test for patchConsents

* feat: remove Stream response option and check for parties response type

* build: Bump version to 10.6.9